### PR TITLE
Add metadata datasource separation for pgconsole schema

### DIFF
--- a/src/main/java/com/bovinemagnet/pgconsole/config/InstanceConfig.java
+++ b/src/main/java/com/bovinemagnet/pgconsole/config/InstanceConfig.java
@@ -77,6 +77,16 @@ public interface InstanceConfig {
     SchemaConfig schema();
 
     /**
+     * Metadata datasource configuration.
+     * <p>
+     * Allows pgconsole schema (metadata storage) to be separate from
+     * the monitored database instances.
+     *
+     * @return metadata configuration
+     */
+    MetadataConfig metadata();
+
+    /**
      * Properties for a specific instance.
      */
     interface InstanceProperties {
@@ -164,6 +174,33 @@ public interface InstanceConfig {
         @WithName("in-memory-minutes")
         @WithDefault("30")
         int inMemoryMinutes();
+    }
+
+    /**
+     * Metadata datasource configuration.
+     * <p>
+     * Allows pgconsole schema (metadata storage) to be stored in a different
+     * database from the monitored instances. This enables:
+     * <ul>
+     *   <li>Read-only monitoring of production databases</li>
+     *   <li>Central metadata store for multi-instance correlation</li>
+     *   <li>Cleaner separation of monitoring metadata from application data</li>
+     * </ul>
+     */
+    interface MetadataConfig {
+        /**
+         * Datasource name for storing pgconsole metadata.
+         * <p>
+         * Options:
+         * <ul>
+         *   <li>Not set / "default": Use the default datasource (backwards compatible)</li>
+         *   <li>"metadata": Use the dedicated metadata datasource</li>
+         *   <li>Instance name: Use a specific instance's datasource</li>
+         * </ul>
+         *
+         * @return datasource name, or empty if not specified
+         */
+        Optional<String> datasource();
     }
 
     /**

--- a/src/main/java/com/bovinemagnet/pgconsole/config/MetadataDataSource.java
+++ b/src/main/java/com/bovinemagnet/pgconsole/config/MetadataDataSource.java
@@ -1,0 +1,42 @@
+package com.bovinemagnet.pgconsole.config;
+
+import jakarta.inject.Qualifier;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * CDI qualifier for the metadata datasource.
+ * <p>
+ * Use this qualifier to inject the datasource used for storing pgconsole
+ * metadata (history, bookmarks, audit logs, alerts, etc.). The actual
+ * datasource resolved depends on configuration:
+ * <ul>
+ *   <li>If {@code pg-console.metadata.datasource} is empty, uses the default datasource</li>
+ *   <li>If set to "metadata", uses the dedicated metadata datasource</li>
+ *   <li>If set to an instance name, uses that instance's datasource</li>
+ * </ul>
+ * <p>
+ * Example usage:
+ * <pre>
+ * &#64;Inject
+ * &#64;MetadataDataSource
+ * DataSource metadataDs;
+ * </pre>
+ *
+ * @author Paul Snow
+ * @version 0.0.0
+ * @see MetadataDataSourceProvider
+ */
+@Qualifier
+@Documented
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD, TYPE})
+public @interface MetadataDataSource {
+}

--- a/src/main/java/com/bovinemagnet/pgconsole/repository/ActiveAlertRepository.java
+++ b/src/main/java/com/bovinemagnet/pgconsole/repository/ActiveAlertRepository.java
@@ -1,5 +1,6 @@
 package com.bovinemagnet.pgconsole.repository;
 
+import com.bovinemagnet.pgconsole.config.MetadataDataSource;
 import com.bovinemagnet.pgconsole.model.ActiveAlert;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -23,6 +24,7 @@ import java.util.Optional;
 public class ActiveAlertRepository {
 
     @Inject
+    @MetadataDataSource
     DataSource dataSource;
 
     /**

--- a/src/main/java/com/bovinemagnet/pgconsole/repository/AlertSilenceRepository.java
+++ b/src/main/java/com/bovinemagnet/pgconsole/repository/AlertSilenceRepository.java
@@ -1,5 +1,6 @@
 package com.bovinemagnet.pgconsole.repository;
 
+import com.bovinemagnet.pgconsole.config.MetadataDataSource;
 import com.bovinemagnet.pgconsole.model.AlertSilence;
 import com.bovinemagnet.pgconsole.model.AlertSilence.Matcher;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -26,6 +27,7 @@ import java.util.Optional;
 public class AlertSilenceRepository {
 
     @Inject
+    @MetadataDataSource
     DataSource dataSource;
 
     private final ObjectMapper objectMapper = new ObjectMapper();

--- a/src/main/java/com/bovinemagnet/pgconsole/repository/ComparisonHistoryRepository.java
+++ b/src/main/java/com/bovinemagnet/pgconsole/repository/ComparisonHistoryRepository.java
@@ -1,5 +1,6 @@
 package com.bovinemagnet.pgconsole.repository;
 
+import com.bovinemagnet.pgconsole.config.MetadataDataSource;
 import com.bovinemagnet.pgconsole.model.ComparisonHistory;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -28,6 +29,7 @@ public class ComparisonHistoryRepository {
     private static final Logger LOG = Logger.getLogger(ComparisonHistoryRepository.class);
 
     @Inject
+    @MetadataDataSource
     DataSource dataSource;
 
     /**

--- a/src/main/java/com/bovinemagnet/pgconsole/repository/ComparisonProfileRepository.java
+++ b/src/main/java/com/bovinemagnet/pgconsole/repository/ComparisonProfileRepository.java
@@ -1,5 +1,6 @@
 package com.bovinemagnet.pgconsole.repository;
 
+import com.bovinemagnet.pgconsole.config.MetadataDataSource;
 import com.bovinemagnet.pgconsole.model.ComparisonFilter;
 import com.bovinemagnet.pgconsole.model.ComparisonProfile;
 import com.bovinemagnet.pgconsole.model.SchemaComparisonResult;
@@ -31,6 +32,7 @@ public class ComparisonProfileRepository {
     private static final Logger LOG = Logger.getLogger(ComparisonProfileRepository.class);
 
     @Inject
+    @MetadataDataSource
     DataSource dataSource;
 
     private final ObjectMapper objectMapper = new ObjectMapper();

--- a/src/main/java/com/bovinemagnet/pgconsole/repository/CustomDashboardRepository.java
+++ b/src/main/java/com/bovinemagnet/pgconsole/repository/CustomDashboardRepository.java
@@ -1,5 +1,6 @@
 package com.bovinemagnet.pgconsole.repository;
 
+import com.bovinemagnet.pgconsole.config.MetadataDataSource;
 import com.bovinemagnet.pgconsole.model.CustomDashboard;
 import com.bovinemagnet.pgconsole.model.CustomWidget;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -24,6 +25,7 @@ import java.util.Optional;
 public class CustomDashboardRepository {
 
     @Inject
+    @MetadataDataSource
     DataSource dataSource;
 
     // ========================================

--- a/src/main/java/com/bovinemagnet/pgconsole/repository/EscalationPolicyRepository.java
+++ b/src/main/java/com/bovinemagnet/pgconsole/repository/EscalationPolicyRepository.java
@@ -1,5 +1,6 @@
 package com.bovinemagnet.pgconsole.repository;
 
+import com.bovinemagnet.pgconsole.config.MetadataDataSource;
 import com.bovinemagnet.pgconsole.model.EscalationPolicy;
 import com.bovinemagnet.pgconsole.model.EscalationPolicy.EscalationTier;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -23,6 +24,7 @@ import java.util.Optional;
 public class EscalationPolicyRepository {
 
     @Inject
+    @MetadataDataSource
     DataSource dataSource;
 
     @Inject

--- a/src/main/java/com/bovinemagnet/pgconsole/repository/HistoryRepository.java
+++ b/src/main/java/com/bovinemagnet/pgconsole/repository/HistoryRepository.java
@@ -1,5 +1,6 @@
 package com.bovinemagnet.pgconsole.repository;
 
+import com.bovinemagnet.pgconsole.config.MetadataDataSource;
 import com.bovinemagnet.pgconsole.model.DatabaseMetricsHistory;
 import com.bovinemagnet.pgconsole.model.QueryMetricsHistory;
 import com.bovinemagnet.pgconsole.model.SystemMetricsHistory;
@@ -24,6 +25,7 @@ import java.util.List;
 public class HistoryRepository {
 
     @Inject
+    @MetadataDataSource
     DataSource dataSource;
 
     /**

--- a/src/main/java/com/bovinemagnet/pgconsole/repository/MaintenanceWindowRepository.java
+++ b/src/main/java/com/bovinemagnet/pgconsole/repository/MaintenanceWindowRepository.java
@@ -1,5 +1,6 @@
 package com.bovinemagnet.pgconsole.repository;
 
+import com.bovinemagnet.pgconsole.config.MetadataDataSource;
 import com.bovinemagnet.pgconsole.model.MaintenanceWindow;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -24,6 +25,7 @@ import java.util.Optional;
 public class MaintenanceWindowRepository {
 
     @Inject
+    @MetadataDataSource
     DataSource dataSource;
 
     /**

--- a/src/main/java/com/bovinemagnet/pgconsole/repository/NotificationChannelRepository.java
+++ b/src/main/java/com/bovinemagnet/pgconsole/repository/NotificationChannelRepository.java
@@ -1,5 +1,6 @@
 package com.bovinemagnet.pgconsole.repository;
 
+import com.bovinemagnet.pgconsole.config.MetadataDataSource;
 import com.bovinemagnet.pgconsole.model.NotificationChannel;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -26,6 +27,7 @@ import java.util.Optional;
 public class NotificationChannelRepository {
 
     @Inject
+    @MetadataDataSource
     DataSource dataSource;
 
     private final ObjectMapper objectMapper = new ObjectMapper();

--- a/src/main/java/com/bovinemagnet/pgconsole/repository/NotificationHistoryRepository.java
+++ b/src/main/java/com/bovinemagnet/pgconsole/repository/NotificationHistoryRepository.java
@@ -1,5 +1,6 @@
 package com.bovinemagnet.pgconsole.repository;
 
+import com.bovinemagnet.pgconsole.config.MetadataDataSource;
 import com.bovinemagnet.pgconsole.model.NotificationChannel;
 import com.bovinemagnet.pgconsole.model.NotificationResult;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -24,6 +25,7 @@ import java.util.Optional;
 public class NotificationHistoryRepository {
 
     @Inject
+    @MetadataDataSource
     DataSource dataSource;
 
     /**

--- a/src/main/java/com/bovinemagnet/pgconsole/service/AuditService.java
+++ b/src/main/java/com/bovinemagnet/pgconsole/service/AuditService.java
@@ -1,5 +1,6 @@
 package com.bovinemagnet.pgconsole.service;
 
+import com.bovinemagnet.pgconsole.config.MetadataDataSource;
 import com.bovinemagnet.pgconsole.model.AuditLog;
 import com.bovinemagnet.pgconsole.model.AuditLog.Action;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -34,6 +35,7 @@ public class AuditService {
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     @Inject
+    @MetadataDataSource
     DataSource dataSource;
 
     /**

--- a/src/main/java/com/bovinemagnet/pgconsole/service/BookmarkService.java
+++ b/src/main/java/com/bovinemagnet/pgconsole/service/BookmarkService.java
@@ -1,5 +1,6 @@
 package com.bovinemagnet.pgconsole.service;
 
+import com.bovinemagnet.pgconsole.config.MetadataDataSource;
 import com.bovinemagnet.pgconsole.model.QueryBookmark;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -29,6 +30,7 @@ public class BookmarkService {
     private static final Logger LOG = Logger.getLogger(BookmarkService.class);
 
     @Inject
+    @MetadataDataSource
     DataSource dataSource;
 
     /**

--- a/src/main/java/com/bovinemagnet/pgconsole/service/MetadataDataSourceProvider.java
+++ b/src/main/java/com/bovinemagnet/pgconsole/service/MetadataDataSourceProvider.java
@@ -1,0 +1,154 @@
+package com.bovinemagnet.pgconsole.service;
+
+import com.bovinemagnet.pgconsole.config.InstanceConfig;
+import com.bovinemagnet.pgconsole.config.MetadataDataSource;
+import io.agroal.api.AgroalDataSource;
+import io.quarkus.agroal.DataSource;
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InstanceHandle;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+/**
+ * Provides the metadata datasource for pgconsole schema storage.
+ * <p>
+ * This provider resolves the appropriate datasource based on configuration:
+ * <ul>
+ *   <li>If {@code pg-console.metadata.datasource} is empty or blank, uses the default datasource
+ *       (backwards compatible behaviour)</li>
+ *   <li>If set to "metadata", uses a dedicated metadata datasource configured as
+ *       {@code quarkus.datasource.metadata.*}</li>
+ *   <li>If set to an instance name (e.g., "shared"), uses that instance's datasource</li>
+ * </ul>
+ * <p>
+ * The resolved datasource is cached and produced for CDI injection using the
+ * {@link MetadataDataSource} qualifier.
+ * <p>
+ * Example configuration:
+ * <pre>
+ * # Use default datasource (backwards compatible)
+ * pg-console.metadata.datasource=
+ *
+ * # Use dedicated metadata datasource
+ * pg-console.metadata.datasource=metadata
+ * quarkus.datasource.metadata.db-kind=postgresql
+ * quarkus.datasource.metadata.jdbc.url=jdbc:postgresql://control:5432/pgconsole
+ *
+ * # Use an existing instance as metadata store
+ * pg-console.metadata.datasource=shared
+ * </pre>
+ *
+ * @author Paul Snow
+ * @version 0.0.0
+ * @see MetadataDataSource
+ * @see InstanceConfig.MetadataConfig
+ */
+@ApplicationScoped
+public class MetadataDataSourceProvider {
+
+    private static final Logger LOG = Logger.getLogger(MetadataDataSourceProvider.class);
+
+    @Inject
+    AgroalDataSource defaultDataSource;
+
+    @Inject
+    InstanceConfig instanceConfig;
+
+    private javax.sql.DataSource resolvedDataSource;
+    private String resolvedDataSourceName;
+
+    /**
+     * Initialises the provider by resolving the configured metadata datasource.
+     */
+    @PostConstruct
+    void init() {
+        var datasourceOpt = instanceConfig.metadata().datasource();
+
+        if (datasourceOpt.isEmpty() || datasourceOpt.get().isBlank() || "default".equals(datasourceOpt.get())) {
+            // Backwards compatible: use default datasource
+            resolvedDataSource = defaultDataSource;
+            resolvedDataSourceName = "default";
+            LOG.info("Metadata datasource: using default datasource (backwards compatible)");
+        } else {
+            // Look up named datasource
+            String datasourceName = datasourceOpt.get();
+            resolvedDataSource = lookupNamedDataSource(datasourceName);
+            resolvedDataSourceName = datasourceName;
+            LOG.infof("Metadata datasource: using named datasource '%s'", datasourceName);
+        }
+    }
+
+    /**
+     * Looks up a named datasource using the Arc CDI container.
+     *
+     * @param name the name of the datasource to look up
+     * @return the datasource for the specified name
+     * @throws IllegalArgumentException if the datasource is not configured or cannot be found
+     */
+    private AgroalDataSource lookupNamedDataSource(String name) {
+        try {
+            InstanceHandle<AgroalDataSource> handle = Arc.container()
+                    .instance(AgroalDataSource.class, new DataSource.DataSourceLiteral(name));
+
+            if (handle.isAvailable()) {
+                LOG.infof("Found metadata datasource: %s", name);
+                return handle.get();
+            } else {
+                LOG.warnf("No datasource configured for metadata: %s. Falling back to default.", name);
+                return defaultDataSource;
+            }
+        } catch (Exception e) {
+            LOG.errorf("Failed to lookup metadata datasource '%s': %s. Falling back to default.",
+                    name, e.getMessage());
+            return defaultDataSource;
+        }
+    }
+
+    /**
+     * Returns the resolved metadata datasource.
+     *
+     * @return the datasource for storing pgconsole metadata
+     */
+    public javax.sql.DataSource getDataSource() {
+        return resolvedDataSource;
+    }
+
+    /**
+     * Returns the name of the resolved datasource.
+     *
+     * @return the datasource name ("default" or the configured name)
+     */
+    public String getDataSourceName() {
+        return resolvedDataSourceName;
+    }
+
+    /**
+     * Checks whether a dedicated metadata datasource is configured.
+     *
+     * @return true if using a non-default datasource for metadata
+     */
+    public boolean isDedicatedMetadataDataSource() {
+        return !"default".equals(resolvedDataSourceName);
+    }
+
+    /**
+     * CDI producer for the metadata datasource.
+     * <p>
+     * Enables injection of the metadata datasource using:
+     * <pre>
+     * &#64;Inject
+     * &#64;MetadataDataSource
+     * DataSource metadataDs;
+     * </pre>
+     *
+     * @return the resolved metadata datasource
+     */
+    @Produces
+    @MetadataDataSource
+    public javax.sql.DataSource produceMetadataDataSource() {
+        return resolvedDataSource;
+    }
+}

--- a/src/main/java/com/bovinemagnet/pgconsole/service/ReportService.java
+++ b/src/main/java/com/bovinemagnet/pgconsole/service/ReportService.java
@@ -1,5 +1,6 @@
 package com.bovinemagnet.pgconsole.service;
 
+import com.bovinemagnet.pgconsole.config.MetadataDataSource;
 import com.bovinemagnet.pgconsole.model.OverviewStats;
 import com.bovinemagnet.pgconsole.model.SlowQuery;
 import io.quarkus.mailer.Mail;
@@ -44,6 +45,7 @@ public class ReportService {
     private static final Logger LOG = Logger.getLogger(ReportService.class);
 
     @Inject
+    @MetadataDataSource
     DataSource dataSource;
 
     @Inject

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -137,6 +137,27 @@ pg-console.instances=${PG_CONSOLE_INSTANCES:default}
 # quarkus.datasource.production.username=${POSTGRES_PRODUCTION_USER}
 # quarkus.datasource.production.password=${POSTGRES_PRODUCTION_PASSWORD}
 
+# Metadata Datasource Configuration
+# =================================
+# Allows pgconsole schema (metadata storage) to be separate from monitored instances.
+# This enables read-only monitoring of production databases.
+#
+# Options:
+#   - Empty (default): Use the default datasource (backwards compatible)
+#   - "metadata": Use a dedicated metadata datasource (configure quarkus.datasource.metadata.*)
+#   - Instance name: Use that instance's datasource for metadata
+#
+# Examples:
+#   pg-console.metadata.datasource=metadata
+#   pg-console.metadata.datasource=shared
+# pg-console.metadata.datasource=${PG_CONSOLE_METADATA_DATASOURCE:}
+
+# Dedicated metadata datasource (only used if pg-console.metadata.datasource=metadata)
+# quarkus.datasource.metadata.db-kind=postgresql
+# quarkus.datasource.metadata.jdbc.url=${PG_CONSOLE_METADATA_URL:jdbc:postgresql://control:5432/pgconsole}
+# quarkus.datasource.metadata.username=${PG_CONSOLE_METADATA_USER:postgres}
+# quarkus.datasource.metadata.password=${PG_CONSOLE_METADATA_PASSWORD:postgres}
+
 # Security Configuration
 # Set to true to enable HTTP Basic authentication
 pg-console.security.enabled=${PG_CONSOLE_SECURITY_ENABLED:false}


### PR DESCRIPTION
  Enable pgconsole schema (metadata storage) to be stored in a separate
  database from monitored PostgreSQL instances. This allows:
  - Read-only monitoring of production databases
  - Central metadata store for multi-instance correlation
  - Cleaner separation of monitoring metadata from application data

  Changes:
  - Add MetadataConfig interface with Optional<String> datasource()
  - Create @MetadataDataSource CDI qualifier annotation
  - Create MetadataDataSourceProvider service with CDI producer
  - Update all 10 repositories to use @MetadataDataSource injection
  - Update AuditService, BookmarkService, ReportService for metadata DS
  - Add --metadata flag to init-schema CLI command
  - Add configuration options in application.properties

  Configuration options:
  - Empty/unset: Use default datasource (backwards compatible)
  - "metadata": Use dedicated quarkus.datasource.metadata.*
  - Instance name: Use that instance's datasource

  All 119 endpoint tests pass with backwards compatibility maintained.